### PR TITLE
:memo: add link to ProjectPier-Core Wiki on GitHub (README.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **ProjectPier** is a *Free, Open-Source, PHP application* for managing tasks, projects and teams through an intuitive web interface. ( [http://www.projectpier.org](http://www.projectpier.org) )
 
+If you are interested in contributing, bugfixing, ... to ProjectPier please visit the [wiki](https://github.com/Project-Pier/ProjectPier-Core/wiki)
+
 ## Reporting Bugs
 
 It is absolutely critical for you to report any bugs you find with this software.
@@ -51,15 +53,15 @@ See [INSTALL.txt](../master/INSTALL.txt)
 Some installations of MySQL don't support *InnoDB* by default.  The ProjectPier installer
 will tell you if your server is not configured to support *InnoDB*. This is easy to fix:
 
-1. Open your MySQL options file, the file name is 
+1. Open your MySQL options file, the file name is
    ```my.cnf``` (Linux) - usually at ```/etc/my.cnf```
    or
    ```my.ini``` (Windows) - usually at ```c:/windows/my.ini```
-   If you are using the Uniform Server on Windows, the file will be named ```my-small``` 
+   If you are using the Uniform Server on Windows, the file will be named ```my-small```
    and will need to be edited with a unix compatible editor such as *SublimeText, Atom, Vim, ...*
 2. Comment the ```skip-innodb``` line by adding ```#``` in front of it (like ```#skip-innodb``` ).
 3. It would also be good to increase ```max_allowed_packet``` to ensure that
-   you'll be able to upload files larger than 1MB. 
+   you'll be able to upload files larger than 1MB.
    Just add this line below the ```#skip-innodb``` line:
 
    ```php
@@ -84,8 +86,8 @@ The following base languages are available:
 
 ## About ProjectPier
 
-ProjectPier is an Open Source project management and collaboration tool that you can install on your own server. 
-It is released under the terms of the Gnu Affero General Public License (AGPL) 
+ProjectPier is an Open Source project management and collaboration tool that you can install on your own server.
+It is released under the terms of the Gnu Affero General Public License (AGPL)
 (see [LICENSE](../master/LICENSE) for details).
 
 [http://www.projectpier.org](http://www.projectpier.org)


### PR DESCRIPTION
We can/should start moving all the coding related information to a [GitHub Wiki](https://github.com/Project-Pier/ProjectPier-Core/wiki) since we moved the issue tracker here. This will simplify things IMO. 
No more clutter on the PP.org site, and the rebuild will be easier too.